### PR TITLE
Lix license, add keywords, optimize format and fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This is a simple MagicMirror module to display ONE Shelly PM sensor data (temperature and power) on Magic Mirror.
+This is a simple module for [MagicMirror²](https://github.com/MagicMirrorOrg/MagicMirror) to display ONE Shelly PM sensor data (temperature and power).
 
 Feel free to extend to fulfill your own needs, This fulfills my needs. See the configuration and some pictures [here](https://github.com/stefanjacobs/MagicMirror).
 
@@ -25,7 +25,7 @@ Feel free to enhance :)
 
 Include this (or multiple instances of it) in your config.js file:
 
-```json
+```js
 {
     module: "MMM-Shelly-PM",
     header: "Shelly-PM",
@@ -53,6 +53,7 @@ Go to your MagicMirror directory
 ```bash
 cd modules
 git clone https://github.com/stefanjacobs/MMM-Shelly-PM
+npm install
 ```
 
 Check out the config.sample.js in the module directory. Copy the content to your config.js and change as necessary. You have to change ShellyApiPath to your device's IP address.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
 	"name": "mmm-shelly-pm",
 	"version": "1.0.0",
-	"description": "bla",
+	"description": "A simple MagicMirror² module to display data from a Shelly-PM device.",
 	"main": "MMM-Shelly-PM.js",
+	"keywords": [
+	    "shelly",
+	    "sensor"
+	],
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
@@ -11,7 +15,7 @@
 		"url": "git+https://github.com/stefanjacobs/MMM-Shelly-PM"
 	},
 	"author": "",
-	"license": "UNLICENSE",
+	"license": "Unlicense",
 	"bugs": {
 		"url": "https://github.com/stefanjacobs/MMM-Shelly-PM/issues"
 	},


### PR DESCRIPTION
License should be a valid [SPDX license expression](https://spdx.org/licenses/).

Keywords are used in the [new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/) I'm working on.